### PR TITLE
panic on hung tasks

### DIFF
--- a/saltstack/salt/core.sls
+++ b/saltstack/salt/core.sls
@@ -26,3 +26,13 @@ ensure_authorized_keys:
       - {{ key }}
       {% endfor %}
 {% endif %}
+
+reboot_five_seconds_after_kernel_panic:
+  sysctl.present:
+    - name: kernel.panic
+    - value: 5
+
+reboot_on_hung_tasks_to_deal_with_nfs_problems:
+  sysctl.present:
+    - name: kernel.hung_task_timeout_secs
+    - value: 180


### PR DESCRIPTION
Reboot whenever NFS blows up and borks the VM:
```
[ 6405.497232] INFO: task someprocess:15654 blocked for more than 120 seconds.
[ 6405.499382]       Not tainted 4.19.0-14-cloud-amd64 #1 Debian 4.19.171-2
[ 6405.501818] "echo 0 > /proc/sys/kernel/hung_task_timeout_secs" disables this message.
[ 6405.505152] someprocess           D    0 15654  15512 0x00000000
[ 6405.507333] Call Trace:
[ 6405.509673]  __schedule+0x29f/0x840
[ 6405.511231]  ? __switch_to_asm+0x41/0x70
[ 6405.512963]  ? bit_wait_timeout+0x90/0x90
[ 6405.514746]  schedule+0x28/0x80
[ 6405.516158]  io_schedule+0x12/0x40
[ 6405.517648]  bit_wait_io+0xd/0x50
[ 6405.519160]  __wait_on_bit+0x73/0x90
[ 6405.520684]  out_of_line_wait_on_bit+0x91/0xb0
[ 6405.522467]  ? init_wait_var_entry+0x40/0x40
[ 6405.524112]  nfs_lock_and_join_requests+0x329/0x4e0 [nfs]
[ 6405.526260]  nfs_updatepage+0x302/0x940 [nfs]
[ 6405.528106]  ? nfs_flush_incompatible+0x157/0x160 [nfs]
[ 6405.530243]  nfs_write_end+0x63/0x4c0 [nfs]
[ 6405.531837]  ? iov_iter_copy_from_user_atomic+0xc3/0x300
[ 6405.533968]  generic_perform_write+0x138/0x1b0
[ 6405.538811]  nfs_file_write+0xdc/0x200 [nfs]
[ 6405.541903]  new_sync_write+0xfb/0x160
[ 6405.543382]  vfs_write+0xa5/0x1a0
[ 6405.544711]  ksys_write+0x57/0xd0
[ 6405.546429]  do_syscall_64+0x50/0xf0
[ 6405.548113]  entry_SYSCALL_64_after_hwframe+0x44/0xa9
[ 6405.550185] RIP: 0033:0x436be1
[ 6405.551476] Code: 24 18 8b 44 24 48 89 04 24 48 8d 44 24 18 48 89 44 24 08 48 c7 44 24 10 00 00 00 00 e8 48 e7 fc ff 48 8b 6c 24 38 48 83 c4 40 <c3> 48 8d 0d 57 fd 2b 04 84 01 48 8b 05 4e fd 2b 04 eb c0 cc cc cc
[ 6405.558985] RSP: 002b:00007ffe6f184cc0 EFLAGS: 00000293 ORIG_RAX: 0000000000000001
[ 6405.561996] RAX: ffffffffffffffda RBX: 00007ffe6f1a5240 RCX: 0000000000436be1
[ 6405.564733] RDX: 00000000003feffe RSI: 00007f0d91ab100d RDI: 000000000000001a
[ 6405.567519] RBP: 00007ffe6f18b0d0 R08: 00007f0d91eafffb R09: 0000000000000000
[ 6405.572608] R10: 0000000000000008 R11: 0000000000000293 R12: 00000000003feffe
[ 6405.575037] R13: 00007f0d91ab100d R14: 00007ffe6f18b0f0 R15: 00000000007fdffd
```