### PR TITLE
global pillar for all roles

### DIFF
--- a/saltstack/pillar/core.sls
+++ b/saltstack/pillar/core.sls
@@ -6,3 +6,7 @@ powerdns_mysql_port: 3306
 powerdns_mysql_dbname: 'powerdns'
 powerdns_mysql_user: 'insecure_powerdns_user'
 powerdns_mysql_password: 'insecure_powerdns_mysql_password'
+shellserver_unprivileged_user_name: 'notroot'
+shellserver_unprivileged_user_full_name: 'Not Root'
+# Insecure default password is 'notroot'. Overwrite this in your own pillar.
+shellserver_unprivileged_user_password_hash: '$6$Fa4ELMtlTwOvhG50$JNbroT9R1Bj0QvER7PYw3Zxn2pnuA/uvj7obVJx0RXauLytV0xecEawUxKRhRaiIfjDWp1dn9tpCKoVd2OEBy/'

--- a/saltstack/pillar/shellserver.sls
+++ b/saltstack/pillar/shellserver.sls
@@ -1,4 +1,0 @@
-shellserver_unprivileged_user_name: 'notroot'
-shellserver_unprivileged_user_full_name: 'Not Root'
-# Insecure default password is 'notroot'. Overwrite this in your own pillar.
-shellserver_unprivileged_user_password_hash: '$6$Fa4ELMtlTwOvhG50$JNbroT9R1Bj0QvER7PYw3Zxn2pnuA/uvj7obVJx0RXauLytV0xecEawUxKRhRaiIfjDWp1dn9tpCKoVd2OEBy/'

--- a/saltstack/pillar/top.sls
+++ b/saltstack/pillar/top.sls
@@ -1,6 +1,3 @@
 base:
   '*':
     - core
-  'role:shellserver':
-    - match: grain
-    - shellserver


### PR DESCRIPTION
everything in the 'core' pillar otherwise I have to keep track of which
module includes which module etc etc to see which role should have which
pillar. for my homelab use-case it's not worth the time to separate that
out. normally you'd want to make sure the minions have as little pillar
data as needed.