### PR TITLE
upsteram pdns namserver is pillar data

### DIFF
--- a/saltstack/pillar/core.sls
+++ b/saltstack/pillar/core.sls
@@ -6,6 +6,8 @@ powerdns_mysql_port: 3306
 powerdns_mysql_dbname: 'powerdns'
 powerdns_mysql_user: 'insecure_powerdns_user'
 powerdns_mysql_password: 'insecure_powerdns_mysql_password'
+powerdns_upstream_nameserver_1: '8.8.8.8'
+powerdns_upstream_nameserver_2: '8.8.4.4'
 shellserver_unprivileged_user_name: 'notroot'
 shellserver_unprivileged_user_full_name: 'Not Root'
 # Insecure default password is 'notroot'. Overwrite this in your own pillar.

--- a/saltstack/salt/powerdns.sls
+++ b/saltstack/salt/powerdns.sls
@@ -11,8 +11,8 @@ remove_resolv_conf_symlink_and_manage_file:
     - name: /etc/resolv.conf
     - follow_symlinks: False
     - contents:
-        - 'nameserver 8.8.8.8'
-        - 'nameserver 8.8.4.4'
+        - "nameserver {{ pillar['powerdns_upstream_nameserver_1'] }}"
+        - "nameserver {{ pillar['powerdns_upstream_nameserver_2'] }}"
 
 install_powerdns_packages:
   pkg.installed:


### PR DESCRIPTION
so I can configure to run homelab dns through pi-hole(s)