### PR TITLE
use powerdns on shellservers

### DIFF
--- a/saltstack/pillar/core.sls
+++ b/saltstack/pillar/core.sls
@@ -8,6 +8,7 @@ powerdns_mysql_user: 'insecure_powerdns_user'
 powerdns_mysql_password: 'insecure_powerdns_mysql_password'
 powerdns_upstream_nameserver_1: '8.8.8.8'
 powerdns_upstream_nameserver_2: '8.8.4.4'
+powerdns_static_ip: '192.168.1.241'
 shellserver_unprivileged_user_name: 'notroot'
 shellserver_unprivileged_user_full_name: 'Not Root'
 # Insecure default password is 'notroot'. Overwrite this in your own pillar.

--- a/saltstack/salt/files/usr/local/bin/update_homelab_zone.sh
+++ b/saltstack/salt/files/usr/local/bin/update_homelab_zone.sh
@@ -8,3 +8,5 @@ done
 pdnsutil delete-zone homelab || /bin/true
 pdnsutil create-zone homelab ns1.homelab
 pdnsutil add-record homelab router A 192.168.1.1
+pdnsutil add-record homelab powerdns A {{ pillar['powerdns_static_ip'] }}
+pdnsutil add-record homelab dns A {{ pillar['powerdns_static_ip'] }}

--- a/saltstack/salt/files/usr/local/bin/use_powerdns_if_up.sh
+++ b/saltstack/salt/files/usr/local/bin/use_powerdns_if_up.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/bash
+set -e
+if ! hostname | grep -q powerdns; then
+    timeout 1 bash -c "</dev/tcp/{{ pillar['powerdns_static_ip'] }}/53 && echo nameserver {{ pillar['powerdns_static_ip'] }} > /etc/resolv.conf" \
+        || bash -c "echo nameserver {{ pillar['powerdns_upstream_nameserver_1'] }} > /etc/resolv.conf"
+fi

--- a/saltstack/salt/powerdns.sls
+++ b/saltstack/salt/powerdns.sls
@@ -121,6 +121,7 @@ write_update_homelab_zone_script:
     - user: root
     - group: root
     - mode: 755
+    - template: jinja
 
 update_homelab_zone:
   cmd.run:

--- a/saltstack/salt/shellserver.sls
+++ b/saltstack/salt/shellserver.sls
@@ -95,6 +95,21 @@ update_motd_periodically:
     - minute: '*'
     - name: /usr/local/bin/update_motd.sh
 
+install_use_powerdns_if_up_script:
+  file.managed:
+    - name: /usr/local/bin/use_powerdns_if_up.sh
+    - source: salt://files/usr/local/bin/use_powerdns_if_up.sh
+    - user: root
+    - group: root
+    - mode: 755
+    - template: jinja
+
+run_use_powerdns_if_up_periodically:
+  cron.present:
+    - user: root
+    - minute: '*'
+    - name: /usr/local/bin/use_powerdns_if_up.sh
+
 ensure_machine_check_tests_dir:
   file.directory:
     - name: /srv/machine-check


### PR DESCRIPTION
but only if it's up, otherwise use the upstream nameserver