### PR TITLE
split shellserver and devenv

### DIFF
--- a/saltstack/salt/desktop.sls
+++ b/saltstack/salt/desktop.sls
@@ -1,5 +1,5 @@
 include:
-  - shellserver
+  - devenv
 
 install_desktop_packages:
   pkg.installed:

--- a/saltstack/salt/devenv.sls
+++ b/saltstack/salt/devenv.sls
@@ -1,0 +1,18 @@
+#!jinja|yaml
+---
+
+include:
+  - shellserver
+
+install_clone_development_projects_script:
+  file.managed:
+    - name: /usr/local/bin/clone_development_projects.sh
+    - source: salt://files/usr/local/bin/clone_development_projects.sh
+    - user: root
+    - group: root
+    - mode: 755
+
+clone_development_projects:
+  cmd.run:
+    - name: /usr/local/bin/clone_development_projects.sh > /tmp/clone_development_projects 2>&1 &
+    - runas: {{ pillar['shellserver_unprivileged_user_name'] }}

--- a/saltstack/salt/shellserver.sls
+++ b/saltstack/salt/shellserver.sls
@@ -294,19 +294,6 @@ configure_vim_if_needed:
       - file: /usr/local/bin/configure_vim.sh
       - git: clone_vundle_repo
 
-install_clone_development_projects_script:
-  file.managed:
-    - name: /usr/local/bin/clone_development_projects.sh
-    - source: salt://files/usr/local/bin/clone_development_projects.sh
-    - user: root
-    - group: root
-    - mode: 755
-
-clone_development_projects:
-  cmd.run:
-    - name: /usr/local/bin/clone_development_projects.sh > /tmp/clone_development_projects 2>&1 &
-    - runas: {{ pillar['shellserver_unprivileged_user_name'] }}
-
 symlink_vimrc_to_root_user_home:
   file.symlink:
     - name: /root/.vimrc

--- a/saltstack/salt/top.sls
+++ b/saltstack/salt/top.sls
@@ -4,6 +4,9 @@ base:
   'role:shellserver':
     - match: grain
     - shellserver
+  'role:devenv':
+    - match: grain
+    - devenv
   'role:desktop':
     - match: grain
     - desktop


### PR DESCRIPTION
not everything that should be on a devenv out of the box should be on
every role that inherits from shellserver (like cloning all projects)