### PR TITLE
install inetutils on archlinux

### DIFF
--- a/saltstack/salt/core.sls
+++ b/saltstack/salt/core.sls
@@ -16,6 +16,7 @@ install_core_packages_for_archlinux:
       - bind
       - gnupg
       - iptables
+      - inetutils
 {% else %}
 install_core_packages_for_debian:
   pkg.installed:

--- a/saltstack/salt/files/srv/machine-check/core.rkt
+++ b/saltstack/salt/files/srv/machine-check/core.rkt
@@ -1,25 +1,27 @@
 ; Install core packages
 (let ((detected-os (detect-os))
-      (shellserver-packages (list
-			      "htop"
-			      "iftop"
-			      "sysstat"
-			      )))
+      (shellserver-packages 
+        (list
+          "htop"
+          "iftop"
+          "sysstat"
+          )))
   (check-packages-installed
     (if (equal? detected-os "arch")
       ; Archlinux packages
       (append shellserver-packages
-	      (list
-		"bind"
-		"iptables"
-	        "gnupg"
+        (list 
+          "bind"
+          "iptables"
+          "inetutils"
+          "gnupg"
 	      ))
       ; Debian packages
       (append shellserver-packages
-	      (list
-		"dnsutils"
-		"iptables-persistent"
-	        "gnupg2"
+        (list
+          "dnsutils"
+          "iptables-persistent"
+          "gnupg2"
 	      )))))
 (check-file-mode "/root/.ssh/id_rsa" 384)
 (check-file-mode "/root/.ssh/authorized_keys" 384)


### PR DESCRIPTION
to make sure the `hostname` command exists