### PR TITLE
also sync buster security

### DIFF
--- a/saltstack/salt/files/mnt/storage/debianrepo/conf/distributions
+++ b/saltstack/salt/files/mnt/storage/debianrepo/conf/distributions
@@ -12,7 +12,7 @@ Origin: Debian Buster updates
 Label: Buster updates
 Suite: buster-updates
 Codename: buster-updates
-Description: Debian Buster mirror
+Description: Debian Buster updates mirror
 Architectures: amd64
 Components: main
 Update: buster-updates
@@ -22,8 +22,18 @@ Origin: Debian Buster backports
 Label: Buster backports
 Suite: buster-backports
 Codename: buster-backports
-Description: Debian Buster mirror
+Description: Debian Buster backports mirror
 Architectures: amd64
 Components: main
-Update: buster-updates
+Update: buster-backports
 Log: /var/log/reprepro/buster-backports.log
+
+Origin: Debian Buster security
+Label: Buster security
+Suite: buster/updates
+Codename: buster-security
+Description: Debian Buster security mirror
+Architectures: amd64
+Components: main
+Update: buster/updates
+Log: /var/log/reprepro/buster-security.log

--- a/saltstack/salt/files/mnt/storage/debianrepo/conf/updates
+++ b/saltstack/salt/files/mnt/storage/debianrepo/conf/updates
@@ -18,3 +18,10 @@ Suite: buster-backports
 Components: main
 Architectures: amd64
 VerifyRelease: blindtrust
+
+Name: buster/updates
+Method: http://security.debian.org/debian-security
+Suite: buster/updates
+Components: main
+Architectures: amd64
+VerifyRelease: blindtrust


### PR DESCRIPTION
not syncing this from utwente lik the rest because:

> Q: Why are there no official mirrors for security.debian.org?
> A: Actually, there are. There are several official mirrors, implemented through DNS aliases. The purpose of security.debian.org is to make security updates available as quickly and easily as possible.
> Encouraging the use of unofficial mirrors would add extra complexity that is usually not needed and that can cause frustration if these mirrors are not kept up to date.

https://www.debian.org/security/faq#mirror