### PR TITLE
host passthrough for nested virtualization

### DIFF
--- a/resources/views.py
+++ b/resources/views.py
@@ -181,6 +181,7 @@ resource "libvirt_domain" "{name}_on_{hypervisor}" {{
   name = "{name}_on_{hypervisor}"
   memory = "{ram}"
   vcpu = {cpu}
+
   cloudinit = libvirt_cloudinit_disk.{name}_on_{hypervisor}_commoninit.id
   
   {nic_config}
@@ -195,6 +196,10 @@ resource "libvirt_domain" "{name}_on_{hypervisor}" {{
     type        = "pty"
     target_type = "virtio"
     target_port = "1"
+  }}
+
+  cpu {{
+    mode = "host-passthrough"
   }}
 
   boot_device {{


### PR DESCRIPTION
Going with host-passthrough instead of host-model because I'm not doing VM migrations anyway (full rebuild with terraform every time). host-model would have been sufficient for nested virtualization though.

> "host-passthrough" - this causes libvirt to tell KVM to passthrough the host CPU with no modifications. The difference to host-model, instead of just matching feature flags, every last detail of the host CPU is matched. This gives absolutely best performance, and can be important to some apps which check low level CPU details, but it comes at a cost wrt migration. The guest can only be migrated to an exactly matching host CPU.

See: https://wiki.openstack.org/wiki/LibvirtXMLCPUModel#:~:text=%22host%2Dpassthrough%22%20%2D%20this,the%20host%20CPU%20is%20matched.