### PR TITLE
increase size of kubernetes nodes

### DIFF
--- a/saltstack/salt/files/usr/local/bin/configure_openstack.sh
+++ b/saltstack/salt/files/usr/local/bin/configure_openstack.sh
@@ -25,6 +25,10 @@ ADMIN_PASSWORD={{ pillar['openstack_stack_password'] }}
 DATABASE_PASSWORD={{ pillar['openstack_stack_password'] }}
 RABBIT_PASSWORD={{ pillar['openstack_stack_password'] }}
 SERVICE_PASSWORD={{ pillar['openstack_stack_password'] }}
+[[post-config|$NOVA_CONF]]
+[DEFAULT]
+disk_allocation_ratio=2.0
+ram_allocation_ratio=2.0
 EOF
 
 FORCE=yes ./stack.sh && echo "Stacking is done!"
@@ -70,10 +74,5 @@ nova quota-update --cores 1000 $(openstack project list | grep -v alt_demo | gre
 openstack quota set --volumes 1000 $(openstack project list | grep -v alt_demo | grep demo | awk '{print$2}')
 openstack quota set --floating-ips 1000 $(openstack project list | grep -v alt_demo | grep demo | awk '{print$2}')
 openstack quota set --ports 1000 $(openstack project list | grep -v alt_demo | grep demo | awk '{print$2}')
-
-echo "Increasing overallocation ratios and reload nova"
-sed -i '1 a cpu_allocation_ratio = 16' /etc/nova/nova.conf
-sed -i '1 a ram_allocation_ratio = 1.5' /etc/nova/nova.conf
-pkill -HUP nova || /bin/true
 
 echo "All done! Go to http://{{ pillar['openstack_static_ip'] }} to log in."

--- a/saltstack/salt/files/usr/local/bin/configure_openstack.sh
+++ b/saltstack/salt/files/usr/local/bin/configure_openstack.sh
@@ -25,10 +25,11 @@ ADMIN_PASSWORD={{ pillar['openstack_stack_password'] }}
 DATABASE_PASSWORD={{ pillar['openstack_stack_password'] }}
 RABBIT_PASSWORD={{ pillar['openstack_stack_password'] }}
 SERVICE_PASSWORD={{ pillar['openstack_stack_password'] }}
-[[post-config|$NOVA_CONF]]
+[[post-config|\$NOVA_CONF]]
 [DEFAULT]
-disk_allocation_ratio=2.0
-ram_allocation_ratio=2.0
+cpu_allocation_ratio = 20.0
+ram_allocation_ratio = 2.0
+disk_allocation_ratio = 1.0
 EOF
 
 FORCE=yes ./stack.sh && echo "Stacking is done!"

--- a/saltstack/salt/files/usr/local/bin/configure_openstack.sh
+++ b/saltstack/salt/files/usr/local/bin/configure_openstack.sh
@@ -25,8 +25,10 @@ ADMIN_PASSWORD={{ pillar['openstack_stack_password'] }}
 DATABASE_PASSWORD={{ pillar['openstack_stack_password'] }}
 RABBIT_PASSWORD={{ pillar['openstack_stack_password'] }}
 SERVICE_PASSWORD={{ pillar['openstack_stack_password'] }}
-CONFIG_NOVA_SCHED_CPU_ALLOC_RATIO=16.0
-CONFIG_NOVA_SCHED_RAM_ALLOC_RATIO=1.5
+[[post-config|$NOVA_CONF]]
+[DEFAULT]
+disk_allocation_ratio=2.0
+ram_allocation_ratio=2.0
 EOF
 
 FORCE=yes ./stack.sh && echo "Stacking is done!"

--- a/saltstack/salt/files/usr/local/bin/configure_openstack.sh
+++ b/saltstack/salt/files/usr/local/bin/configure_openstack.sh
@@ -29,7 +29,7 @@ SERVICE_PASSWORD={{ pillar['openstack_stack_password'] }}
 [DEFAULT]
 cpu_allocation_ratio = 20.0
 ram_allocation_ratio = 2.0
-disk_allocation_ratio = 1.0
+disk_allocation_ratio = 2.0
 EOF
 
 FORCE=yes ./stack.sh && echo "Stacking is done!"

--- a/saltstack/salt/files/usr/local/bin/configure_openstack.sh
+++ b/saltstack/salt/files/usr/local/bin/configure_openstack.sh
@@ -25,10 +25,6 @@ ADMIN_PASSWORD={{ pillar['openstack_stack_password'] }}
 DATABASE_PASSWORD={{ pillar['openstack_stack_password'] }}
 RABBIT_PASSWORD={{ pillar['openstack_stack_password'] }}
 SERVICE_PASSWORD={{ pillar['openstack_stack_password'] }}
-[[post-config|$NOVA_CONF]]
-[DEFAULT]
-disk_allocation_ratio=2.0
-ram_allocation_ratio=2.0
 EOF
 
 FORCE=yes ./stack.sh && echo "Stacking is done!"
@@ -74,5 +70,10 @@ nova quota-update --cores 1000 $(openstack project list | grep -v alt_demo | gre
 openstack quota set --volumes 1000 $(openstack project list | grep -v alt_demo | grep demo | awk '{print$2}')
 openstack quota set --floating-ips 1000 $(openstack project list | grep -v alt_demo | grep demo | awk '{print$2}')
 openstack quota set --ports 1000 $(openstack project list | grep -v alt_demo | grep demo | awk '{print$2}')
+
+echo "Increasing overallocation ratios and reload nova"
+sed -i '1 a cpu_allocation_ratio = 16' /etc/nova/nova.conf
+sed -i '1 a ram_allocation_ratio = 1.5' /etc/nova/nova.conf
+pkill -HUP nova || /bin/true
 
 echo "All done! Go to http://{{ pillar['openstack_static_ip'] }} to log in."

--- a/saltstack/salt/files/usr/local/bin/configure_rancher.sh
+++ b/saltstack/salt/files/usr/local/bin/configure_rancher.sh
@@ -79,7 +79,7 @@ cat << EOF > /tmp/node_template.json
     "domainName": "default",
     "endpointType": "",
     "flavorId": "",
-    "flavorName": "ds2G",
+    "flavorName": "ds4G",
     "floatingipPool": "public",
     "imageId": "",
     "imageName": "focal-server-cloudimg-amd64",


### PR DESCRIPTION
4 vcpu, 4GB ram

edit: still getting "nova.exception.NoValidHost: No valid host was found." for some reason

extra information:
```
mysql> use nova_cell1;
Database changed
mysql> select * from compute_nodes\G;
*************************** 1. row ***************************
           created_at: 2022-04-10 14:06:03
           updated_at: 2022-04-10 14:16:13
           deleted_at: NULL
                   id: 1
           service_id: NULL
                vcpus: 8
            memory_mb: 50212
             local_gb: 97
           vcpus_used: 16
       memory_mb_used: 16896
        local_gb_used: 80
      hypervisor_type: QEMU
   hypervisor_version: 4002001
             cpu_info: {"arch": "x86_64", "model": "Broadwell", "vendor": "Intel", "topology": {"cells": 1, "sockets": 8, "cores": 1, "threads": 1}, "features": ["sse", "movbe", "cmov", "fpu", "sse4.2", "de", "pse", "f16c", "adx", "erms", "pni", "fxsr", "mca", "cx16", "clflush", "pat", "nx", "pschange-mc-no", "pclmuldq", "ss", "pse36", "sep", "lm", "rdrand", "aes", "x2apic", "xsaveopt", "arat", "clflushopt", "rtm", "apic", "umip", "cx8", "mtrr", "xsavec", "mmx", "pcid", "bmi2", "syscall", "sse4.1", "avx2", "fma", "fsgsbase", "msr", "ssse3", "xgetbv1", "xsave", "avx", "3dnowprefetch", "smep", "pdpe1gb", "lahf_lm", "rdtscp", "sse2", "hypervisor", "tsc-deadline", "smap", "tsc_adjust", "mce", "pge", "vmx", "skip-l1dfl-vmentry", "abm", "xsaves", "hle", "invpcid", "rdseed", "arch-capabilities", "vme", "bmi1", "pae", "tsc", "popcnt"]}
 disk_available_least: -4
          free_ram_mb: 33316
         free_disk_gb: 17
     current_workload: 0
          running_vms: 4
  hypervisor_hostname: openstack-on-hypervisor
              deleted: 0
              host_ip: 192.168.1.248
  supported_instances: [["alpha", "qemu", "hvm"], ["armv7l", "qemu", "hvm"], ["aarch64", "qemu", "hvm"], ["cris", "qemu", "hvm"], ["i686", "qemu", "hvm"], ["i686", "kvm", "hvm"], ["lm32", "qemu", "hvm"], ["m68k", "qemu", "hvm"], ["microblaze", "qemu", "hvm"], ["microblazeel", "qemu", "hvm"], ["mips", "qemu", "hvm"], ["mipsel", "qemu", "hvm"], ["mips64", "qemu", "hvm"], ["mips64el", "qemu", "hvm"], ["ppc", "qemu", "hvm"], ["ppc64", "qemu", "hvm"], ["ppc64le", "qemu", "hvm"], ["s390x", "qemu", "hvm"], ["sh4", "qemu", "hvm"], ["sh4eb", "qemu", "hvm"], ["sparc", "qemu", "hvm"], ["sparc64", "qemu", "hvm"], ["unicore32", "qemu", "hvm"], ["x86_64", "qemu", "hvm"], ["x86_64", "kvm", "hvm"], ["xtensa", "qemu", "hvm"], ["xtensaeb", "qemu", "hvm"]]
            pci_stats: {"nova_object.name": "PciDevicePoolList", "nova_object.namespace": "nova", "nova_object.version": "1.1", "nova_object.data": {"objects": []}, "nova_object.changes": ["objects"]}
              metrics: []
      extra_resources: NULL
                stats: {"failed_builds": "1", "num_instances": "4", "num_vm_active": "4", "num_task_None": "4", "num_os_type_None": "4", "num_proj_be2681f4f0724326ab23990d8f264684": "4", "io_workload": "0"}
        numa_topology: {"nova_object.name": "NUMATopology", "nova_object.namespace": "nova", "nova_object.version": "1.2", "nova_object.data": {"cells": [{"nova_object.name": "NUMACell", "nova_object.namespace": "nova", "nova_object.version": "1.5", "nova_object.data": {"id": 0, "cpuset": [0, 1, 2, 3, 4, 5, 6, 7], "pcpuset": [0, 1, 2, 3, 4, 5, 6, 7], "memory": 50212, "cpu_usage": 0, "memory_usage": 0, "pinned_cpus": [], "siblings": [[6], [2], [5], [4], [1], [7], [0], [3]], "mempages": [{"nova_object.name": "NUMAPagesTopology", "nova_object.namespace": "nova", "nova_object.version": "1.1", "nova_object.data": {"size_kb": 4, "total": 12854472, "used": 0, "reserved": 0}, "nova_object.changes": ["used", "reserved", "total", "size_kb"]}, {"nova_object.name": "NUMAPagesTopology", "nova_object.namespace": "nova", "nova_object.version": "1.1", "nova_object.data": {"size_kb": 2048, "total": 0, "used": 0, "reserved": 0}, "nova_object.changes": ["used", "reserved", "total", "size_kb"]}, {"nova_object.name": "NUMAPagesTopology", "nova_object.namespace": "nova", "nova_object.version": "1.1", "nova_object.data": {"size_kb": 1048576, "total": 0, "used": 0, "reserved": 0}, "nova_object.changes": ["used", "reserved", "total", "size_kb"]}], "network_metadata": {"nova_object.name": "NetworkMetadata", "nova_object.namespace": "nova", "nova_object.version": "1.0", "nova_object.data": {"physnets": [], "tunneled": false}, "nova_object.changes": ["physnets", "tunneled"]}, "socket": null}, "nova_object.changes": ["memory", "memory_usage", "pinned_cpus", "mempages", "pcpuset", "socket", "network_metadata", "cpu_usage", "id", "cpuset", "siblings"]}]}, "nova_object.changes": ["cells"]}
                 host: openstack-on-hypervisor
 ram_allocation_ratio: 2
 cpu_allocation_ratio: 20
                 uuid: 41798aa4-d2af-42d1-81ce-a10cb70f3117
disk_allocation_ratio: 1
               mapped: 1
1 row in set (0.00 sec)

ERROR: 
No query specified
```

edit 2: was running into `disk_allocation_ratio`, not cpu or ram.