### PR TITLE
work around ImagePullBackOff (for fat container)

### DIFF
--- a/saltstack/salt/files/usr/local/bin/configure_rancher.sh
+++ b/saltstack/salt/files/usr/local/bin/configure_rancher.sh
@@ -91,6 +91,11 @@ cat << 'EOF' > /tmp/homelabmanagercluster.json
         },
         "services": {
             "type": "rkeConfigServices",
+            "kubelet": {
+                "extraArgs": {
+                    "runtime-request-timeout": "10m"
+                }
+            },
             "kubeApi": {
                 "alwaysPullImages": false,
                 "podSecurityPolicy": false,


### PR DESCRIPTION
trying to run a big container image on slow disks. this is a workaround for:
```
ImagePullBackOff (Back-off pulling image "someimage/someimage/someimage:latest")
ErrImagePull (rpc error: code = Unknown desc = Error response from daemon: Get "https://someimage/v2/": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers))
```

edit: looks like this doesn't work, still getting 'Error: ImagePullBackOff'