### PR TITLE
use new jenkins gpg key

### DIFF
--- a/saltstack/salt/jenkinsci.sls
+++ b/saltstack/salt/jenkinsci.sls
@@ -7,7 +7,7 @@ jenkins_repository:
     - name: deb https://pkg.jenkins.io/debian-stable binary/
     - file: /etc/apt/sources.list.d/jenkins.list
     - gpgcheck: 1
-    - key_url: https://pkg.jenkins.io/debian-stable/jenkins.io.key
+    - key_url: https://pkg.jenkins.io/debian-stable/jenkins.io-2023.key
 
 install_jenkinsci_packages:
   pkg.installed:


### PR DESCRIPTION
key was updated, see https://pkg.origin.jenkins.io/debian-stable/