### PR TITLE
upgrade devstack

### DIFF
--- a/saltstack/salt/files/usr/local/bin/configure_openstack.sh
+++ b/saltstack/salt/files/usr/local/bin/configure_openstack.sh
@@ -10,7 +10,7 @@ fi
 git clone https://github.com/openstack/devstack.git
 cd devstack
 git fetch
-git checkout stable/yoga
+git checkout stable/2024.2
 GIT_BASE_IF_NEEDED=""
 if [ -d /mnt/storage/openstack ]; then
     GIT_BASE_IF_NEEDED="GIT_BASE=file:///mnt/storage/openstack"


### PR DESCRIPTION
to fix:
```
$ cat configure_openstack_log
Cloning into 'devstack'...
error: pathspec 'stable/yoga' did not match any file(s) known to git
```