### PR TITLE
pin old version of terraform-provider-libvirt

### DIFF
--- a/resources/views.py
+++ b/resources/views.py
@@ -10,6 +10,7 @@ terraform {
   required_providers {
     libvirt = {
       source  = "dmacvicar/libvirt"
+      version = "~> 0.7.6"
     }
   }
 }


### PR DESCRIPTION
breaking changes after v0.8.0, see https://github.com/dmacvicar/terraform-provider-libvirt/releases